### PR TITLE
Added rate limit check for TMDB API

### DIFF
--- a/PlexUnify.py
+++ b/PlexUnify.py
@@ -982,9 +982,17 @@ def retrieve_web_page(url, page_name='page'):
                 print('Breaking out of loop and committing')
                 commit_to_database()
                 sys.exit()
-
+    rate_limit_check(response.headers)
     return response
 
+def rate_limit_check(header):
+    try:
+        limit = int(header['x-ratelimit-remaining'])
+    except:
+        limit = 40
+    if limit < 1:
+        print(Rate limit with TMDB API hit. Will pause for 10 seconds')
+        time.sleep(10)
 
 def get_tmdb_movie_id(movie):
     if len(movie['imdb_id']) != 9:


### PR DESCRIPTION
[TMDB has a rate limit of 40 queries per 10 seconds.](https://developers.themoviedb.org/3/getting-started/request-rate-limiting) This code is a crude way to avoid hitting those limits when running this script against an entire library. There is likely a better way to calculate the pause time instead of hardcoding 10 seconds but this should work well enough.